### PR TITLE
Bugfix - missing team controller exception

### DIFF
--- a/app/Http/Breadcrumbs/Backend/Backend.php
+++ b/app/Http/Breadcrumbs/Backend/Backend.php
@@ -7,7 +7,7 @@ Breadcrumbs::register('admin.donations', function ($breadcrumbs) {
     $breadcrumbs->push('Donations', route('admin.donations'));
 });
 Breadcrumbs::register('teams.index', function ($breadcrumbs) {
-    $breadcrumbs->push('Teams', route('teams.index'));
+    $breadcrumbs->push('Teams', route('admin.teams.index'));
 });
 Breadcrumbs::register('messenger.index', function ($breadcrumbs) {
     $breadcrumbs->push('Messenger', route('messenger.index'));

--- a/app/Http/Controllers/Backend/Teamwork/AuthController.php
+++ b/app/Http/Controllers/Backend/Teamwork/AuthController.php
@@ -25,7 +25,7 @@ class AuthController extends Controller
 
         if (auth()->check()) {
             Teamwork::acceptInvite($invite);
-            return redirect()->route('teams.index');
+            return redirect()->route('admin.teams.index');
         } else {
             session(['invite_token' => $token]);
             return redirect()->to('login');
@@ -42,7 +42,7 @@ class AuthController extends Controller
 
         if (auth()->check()) {
             Teamwork::denyInvite($invite);
-            return redirect()->route('teams.index');
+            return redirect()->route('admin.teams.index');
         }
 
         session(['invite_token' => $token]);

--- a/app/Http/Controllers/Backend/Teamwork/AuthController.php
+++ b/app/Http/Controllers/Backend/Teamwork/AuthController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Teamwork;
+namespace App\Http\Controllers\Backend\Teamwork;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;

--- a/app/Http/Controllers/Backend/Teamwork/AuthController.php.bak
+++ b/app/Http/Controllers/Backend/Teamwork/AuthController.php.bak
@@ -25,7 +25,7 @@ class AuthController extends Controller
 
         if (auth()->check()) {
             Teamwork::acceptInvite($invite);
-            return redirect()->route('teams.index');
+            return redirect()->route('admin.teams.index');
         } else {
             session(['invite_token' => $token]);
             return redirect()->to('login');

--- a/app/Http/Controllers/Backend/Teamwork/AuthController.php.bak
+++ b/app/Http/Controllers/Backend/Teamwork/AuthController.php.bak
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Teamwork;
+namespace App\Http\Controllers\Backend\Teamwork;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;

--- a/app/Http/Controllers/Backend/Teamwork/TeamController.php
+++ b/app/Http/Controllers/Backend/Teamwork/TeamController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Teamwork;
+namespace App\Http\Controllers\Backend\Teamwork;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;

--- a/app/Http/Controllers/Backend/Teamwork/TeamController.php
+++ b/app/Http/Controllers/Backend/Teamwork/TeamController.php
@@ -64,7 +64,7 @@ class TeamController extends Controller
 
         $request->user()->attachTeam($team);
 
-        return redirect(route('teams.index'));
+        return redirect(route('admin.teams.index'));
     }
 
     /**
@@ -98,7 +98,7 @@ class TeamController extends Controller
             abort(403);
         }
 
-        return redirect(route('teams.index'));
+        return redirect(route('admin.teams.index'));
     }
 
     public function seeTeam($id)
@@ -174,7 +174,7 @@ class TeamController extends Controller
         $team->name = $request->name;
         $team->save();
 
-        return redirect(route('teams.index'));
+        return redirect(route('admin.teams.index'));
     }
 
     /**
@@ -198,6 +198,6 @@ class TeamController extends Controller
         $userModel::where('current_team_id', $id)
                     ->update(['current_team_id' => null]);
 
-        return redirect(route('teams.index'));
+        return redirect(route('admin.teams.index'));
     }
 }

--- a/app/Http/Controllers/Backend/Teamwork/TeamMemberController.php
+++ b/app/Http/Controllers/Backend/Teamwork/TeamMemberController.php
@@ -53,7 +53,7 @@ class TeamMemberController extends Controller
 
         $user->detachTeam($team);
 
-        return redirect(route('teams.index'));
+        return redirect(route('admin.teams.index'));
     }
 
 
@@ -67,7 +67,7 @@ class TeamMemberController extends Controller
 
         $user->detachTeam($team);
 
-        return redirect(route('teams.index'));
+        return redirect(route('admin.teams.index'));
     }
 
     /**
@@ -96,7 +96,7 @@ class TeamMemberController extends Controller
             ]);
         }
 
-        return redirect(route('teams.members.show', $team->id));
+        return redirect(route('admin.teams.members.show', $team->id));
     }
 
     /**
@@ -112,7 +112,7 @@ class TeamMemberController extends Controller
             $m->to($invite->email)->subject('Invitation to join team '.$invite->team->name);
         });
 
-        return redirect(route('teams.members.show', $invite->team));
+        return redirect(route('admin.teams.members.show', $invite->team));
     }
 
 }

--- a/app/Http/Controllers/Backend/Teamwork/TeamMemberController.php
+++ b/app/Http/Controllers/Backend/Teamwork/TeamMemberController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Teamwork;
+namespace App\Http\Controllers\Backend\Teamwork;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;

--- a/resources/views/backend/includes/sidebar.blade.php
+++ b/resources/views/backend/includes/sidebar.blade.php
@@ -37,7 +37,7 @@
                     <span>{{ trans('menus.backend.sidebar.dashboard') }}</span> {{-- Name of link--}}
                 </a>
             </li>
-            
+
             <li class="{{ active_class(Active::checkUriPattern('admin/donations*')) }}"> {{-- Set Active--}}
                 <a href="{{ route('admin.donations') }}"> {{-- Route --}}
                     <i class="fa fa-money"></i> {{-- Icon --}}
@@ -46,19 +46,19 @@
             </li>
 
             <li class="{{ active_class(Active::checkUriPattern('admin/teams*')) }}"> {{-- Set Active--}}
-                <a href="{{route('teams.index')}}"> {{-- Route --}}
+                <a href="{{route('admin.teams.index')}}"> {{-- Route --}}
                     <i class="fa fa-users"></i> {{-- Icon --}}
                     <span>Teams</span> {{-- Name of link--}}
                 </a>
             </li>
-            
+
             <li class="{{ active_class(Active::checkUriPattern('admin/messaging*')) }}"> {{-- Set Active--}}
                 <a href="{{route('messenger.index')}}"> {{-- Route --}}
                     <i class="fa fa-comments"></i> {{-- Icon --}}
                     <span>Messaging</span> {{-- Name of link--}}
                 </a>
             </li>
-            
+
             <li class="{{ active_class(Active::checkUriPattern('admin/members*')) }}"> {{-- Set Active--}}
                 <a href="{{ route('admin.members.index') }}"> {{-- Route --}}
                     <i class="fa fa-user-circle-o"></i> {{-- Icon --}}
@@ -72,7 +72,7 @@
             @role(1)
             <li class="header">Admin</li>
 
-            
+
             <li class="{{ active_class(Active::checkUriPattern('admin/access/*')) }} treeview">
                 <a href="#">
                     <i class="fa fa-users"></i>
@@ -96,7 +96,7 @@
                     </li>
                 </ul>
             </li>
-            
+
              <li class="{{ active_class(Active::checkUriPattern('admin/log-viewer*')) }} treeview">
                 <a href="#">
                     <i class="fa fa-list"></i>
@@ -131,7 +131,7 @@
                     <i class="fa fa-angle-left pull-right"></i>
                 </a>
                 <ul class="treeview-menu {{ active_class(Active::checkUriPattern('admin/news*'), 'menu-open') }}" style="display: none; {{ active_class(Active::checkUriPattern('admin/news*'), 'display: block;') }}">
-                    
+
                     <li class="{{ active_class(Active::checkUriPattern('admin/news')) }}">
                         <a href="{{route('admin.news.index')}}">
                             <i class="fa fa-circle-o"></i>
@@ -145,11 +145,11 @@
                         </a>
                     </li>
 
-                    
+
                 </ul>
             </li>
-            
-       
+
+
 
             <li class="{{ active_class(Active::checkUriPattern('admin/events*')) }} treeview">
                 <a href="#">
@@ -158,15 +158,15 @@
                     <i class="fa fa-angle-left pull-right"></i>
                 </a>
                 <ul class="treeview-menu treeview-menu {{ active_class(Active::checkUriPattern('admin/events*'), 'menu-open') }}" style="display: none; {{ active_class(Active::checkUriPattern('admin/events*'), 'display: block;') }}">
-                    
+
                     <li class="{{ active_class(Active::checkUriPattern('admin/events')) }}">
                         <a href="{{route('admin.events.index')}}">
                             <i class="fa fa-circle-o"></i>
                             <span>View</span>
                         </a>
                     </li>
-                    
-                    
+
+
                     <li class="{{ active_class(Active::checkUriPattern('admin/events/create')) }}">
                         <a href="{{route('admin.events.create')}}">
                             <i class="fa fa-circle-o"></i>
@@ -174,7 +174,7 @@
                         </a>
                     </li>
 
-                    
+
                 </ul>
             </li>
 
@@ -229,7 +229,7 @@
 
             @endauth
 
-           
+
         </ul><!-- /.sidebar-menu -->
     </section><!-- /.sidebar -->
 </aside>

--- a/resources/views/teamwork/create.blade.php
+++ b/resources/views/teamwork/create.blade.php
@@ -7,7 +7,7 @@
                 <div class="panel panel-default">
                     <div class="panel-heading">Create a new team</div>
                     <div class="panel-body">
-                        <form class="form-horizontal" method="post" action="{{route('teams.store')}}">
+                        <form class="form-horizontal" method="post" action="{{route('admin.teams.store')}}">
                             {!! csrf_field() !!}
 
                             <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">
@@ -30,7 +30,7 @@
                                     <button type="submit" class="btn btn-primary">
                                         <i class="fa fa-btn fa-save"></i> Save
                                     </button>
-                                    <a href="{{route('teams.index')}}" class="btn btn-warning">
+                                    <a href="{{route('admin.teams.index')}}" class="btn btn-warning">
                                         <i class="fa fa-btn fa-ban"></i> Cancel
                                     </a>
                                 </div>

--- a/resources/views/teamwork/edit.blade.php
+++ b/resources/views/teamwork/edit.blade.php
@@ -7,7 +7,7 @@
                 <div class="panel panel-default">
                     <div class="panel-heading">Edit team {{$team->name}}</div>
                     <div class="panel-body">
-                        <form class="form-horizontal" method="post" action="{{route('teams.update', $team)}}">
+                        <form class="form-horizontal" method="post" action="{{route('admin.teams.update', $team)}}">
                             <input type="hidden" name="_method" value="PUT" />
                             {!! csrf_field() !!}
 

--- a/resources/views/teamwork/emails/invite.blade.php
+++ b/resources/views/teamwork/emails/invite.blade.php
@@ -91,11 +91,11 @@ text-align: center; text-decoration: none; -webkit-text-size-adjust: none;',
                           $actionColor = 'button--blue';
                           $denyColor = 'button--red';
                           ?>
-                            <a href="{{route('teams.accept_invite', $invite->accept_token)}}"  style="{{ $fontFamily }} {{ $style['button'] }} {{ $style[$actionColor] }}"
+                            <a href="{{route('admin.teams.accept_invite', $invite->accept_token)}}"  style="{{ $fontFamily }} {{ $style['button'] }} {{ $style[$actionColor] }}"
                             class="button"
                             target="_blank">Accept Invite</a>
 
-                            <a href="{{route('teams.deny_invite', $invite->deny_token)}}"  style="{{ $fontFamily }} {{ $style['button'] }} {{ $style[$denyColor] }}"
+                            <a href="{{route('admin.teams.deny_invite', $invite->deny_token)}}"  style="{{ $fontFamily }} {{ $style['button'] }} {{ $style[$denyColor] }}"
                             class="button"
                             target="_blank">Deny Invite</a>
                         </td>

--- a/resources/views/teamwork/emails/invite.blade.php.bak
+++ b/resources/views/teamwork/emails/invite.blade.php.bak
@@ -1,2 +1,2 @@
 You have been invited to join team {{$team->name}}.<br>
-Click here to join: <a href="{{route('teams.accept_invite', $invite->accept_token)}}">{{route('teams.accept_invite', $invite->accept_token)}}</a>
+Click here to join: <a href="{{route('admin.teams.accept_invite', $invite->accept_token)}}">{{route('admin.teams.accept_invite', $invite->accept_token)}}</a>

--- a/resources/views/teamwork/index.blade.php
+++ b/resources/views/teamwork/index.blade.php
@@ -21,7 +21,7 @@
                 <div class="panel panel-default">
                     <div class="panel-heading clearfix">
                         Your Teams
-                        <a class="pull-right btn btn-default btn-sm" href="{{route('teams.create')}}">
+                        <a class="pull-right btn btn-default btn-sm" href="{{route('admin.teams.create')}}">
                             <i class="fa fa-plus"></i> Create team
                         </a>
                     </div>
@@ -49,28 +49,28 @@
                                         </td>
                                         <td>
                                             @if(is_null(auth()->user()->currentTeam) || auth()->user()->currentTeam->getKey() !== $team->getKey())
-                                                <a href="{{route('teams.switch', $team)}}" class="btn btn-sm btn-default">
+                                                <a href="{{route('admin.teams.switch', $team)}}" class="btn btn-sm btn-default">
                                                     <i class="fa fa-sign-in"></i> Switch
                                                 </a>
                                             @else
                                                 <span class="label label-default">Current team</span>
                                             @endif
 
-                                            <a href="{{route('teams.members.show', $team)}}" class="btn btn-sm btn-default">
+                                            <a href="{{route('admin.teams.members.show', $team)}}" class="btn btn-sm btn-default">
                                                 <i class="fa fa-users"></i> Members
                                             </a>
 
                                             @if(auth()->user()->isOwnerOfTeam($team))
 
-                                                <a href="{{route('teams.edit', $team)}}" class="btn btn-sm btn-default">
+                                                <a href="{{route('admin.teams.edit', $team)}}" class="btn btn-sm btn-default">
                                                     <i class="fa fa-pencil"></i> Edit
                                                 </a>
-                                                <a href="{{route('teams.create.event',$team->id)}}" class="btn btn-sm btn-default">
+                                                <a href="{{route('admin.teams.create.event',$team->id)}}" class="btn btn-sm btn-default">
                                                     <i class="fa fa-plus"></i> Event
                                                 </a>
 
 
-                                                <form style="display: inline-block;" action="{{route('teams.destroy', $team)}}" method="post">
+                                                <form style="display: inline-block;" action="{{route('admin.teams.destroy', $team)}}" method="post">
                                                     {!! csrf_field() !!}
                                                     <input type="hidden" name="_method" value="DELETE" />
                                                     <button class="btn btn-danger btn-sm"><i class="fa fa-trash-o"></i> Delete</button>
@@ -79,7 +79,7 @@
                                             <?php
                                             $user = Auth::user()->id;
                                             ?>
-                                            <form style="display: inline-block;" action="{{route('teams.members.leave', [$team, $user])}} "  id="leave" method="post">
+                                            <form style="display: inline-block;" action="{{route('admin.teams.members.leave', [$team, $user])}} "  id="leave" method="post">
                                                     {!! csrf_field() !!}
                                                     <input type="hidden" name="_method" value="DELETE" />
                                                     <button class="btn btn-warning btn-sm leave-team"   ><i class="fa fa-sign-out" ></i> Leave</button>
@@ -95,14 +95,14 @@
                     </div>
                 </div>
             </div>
-            
-            
-            
+
+
+
                <div class="col-md-8 col-md-offset-2">
                 <div class="panel panel-default">
                     <div class="panel-heading clearfix">
                         Teams List
-                        
+
                     </div>
                     <div class="panel-body">
                         <table class="table table-striped">
@@ -163,13 +163,13 @@
 
 -->
 <!--
-                                            <a href="{{route('teams.view',$teams->id)}}" class="btn btn-sm btn-default">
+                                            <a href="{{route('admin.teams.view',$teams->id)}}" class="btn btn-sm btn-default">
                                                 <i class="fa fa-sign-in"></i> Join
-                                            </a> 
+                                            </a>
 -->
                                         </td>
                                         <td>
- 
+
                                         </td>
                                     </tr>
                                 @endforeach
@@ -181,7 +181,7 @@
             </div>
         </div>
     </div>
-<input type="hidden" name="join-team" id="join-team" value="{{route('teams.join')}}">
+<input type="hidden" name="join-team" id="join-team" value="{{route('admin.teams.join')}}">
 
 @section('after-scripts')
 

--- a/resources/views/teamwork/members/list.blade.php
+++ b/resources/views/teamwork/members/list.blade.php
@@ -7,7 +7,7 @@
                 <div class="panel panel-default">
                     <div class="panel-heading clearfix">
                         Members of team "{{$team->name}}"
-                        <a href="{{route('teams.index')}}" class="btn btn-sm btn-default pull-right">
+                        <a href="{{route('admin.teams.index')}}" class="btn btn-sm btn-default pull-right">
                             <i class="fa fa-arrow-left"></i> Back
                         </a>
                     </div>
@@ -25,7 +25,7 @@
                                     <td>
                                         @if(auth()->user()->isOwnerOfTeam($team))
                                             @if(auth()->user()->getKey() !== $user->getKey())
-                                                <form style="display: inline-block;" action="{{route('teams.members.destroy', [$team, $user])}}" method="post">
+                                                <form style="display: inline-block;" action="{{route('admin.teams.members.destroy', [$team, $user])}}" method="post">
                                                     {!! csrf_field() !!}
                                                     <input type="hidden" name="_method" value="DELETE" />
                                                     <button class="btn btn-danger btn-sm"><i class="fa fa-trash-o"></i> Delete</button>
@@ -56,7 +56,7 @@
                                 <tr>
                                     <td>{{$invite->email}}</td>
                                     <td>
-                                        <a href="{{route('teams.members.resend_invite', $invite)}}" class="btn btn-sm btn-default">
+                                        <a href="{{route('admin.teams.members.resend_invite', $invite)}}" class="btn btn-sm btn-default">
                                             <i class="fa fa-envelope-o"></i> Resend invite
                                         </a>
                                     </td>
@@ -70,7 +70,7 @@
                 <div class="panel panel-default">
                     <div class="panel-heading clearfix">Invite to team "{{$team->name}}"</div>
                     <div class="panel-body">
-                        <form class="form-horizontal" method="post" action="{{route('teams.members.invite', $team)}}">
+                        <form class="form-horizontal" method="post" action="{{route('admin.teams.members.invite', $team)}}">
                             {!! csrf_field() !!}
                             <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
                                 <label class="col-md-4 control-label">E-Mail Address</label>

--- a/routes/Backend/Team/Team.php
+++ b/routes/Backend/Team/Team.php
@@ -1,26 +1,34 @@
 <?php
 
-    Route::get('/', 'TeamController@index')->name('teams.index');
-    Route::get('create', 'TeamController@create')->name('teams.create');
-    Route::post('teams', 'TeamController@store')->name('teams.store');
-    Route::get('edit/{id}', 'TeamController@edit')->name('teams.edit');
-    Route::put('edit/{id}', 'TeamController@update')->name('teams.update');
-    Route::delete('destroy/{id}', 'TeamController@destroy')->name('teams.destroy');
+Route::group([
+    'prefix'     => 'teams',
+    'as'         => 'teams.',
+    'namespace' => 'Teamwork'
 
-    Route::get('switch/{id}', 'TeamController@switchTeam')->name('teams.switch');
-    Route::post('join', 'TeamController@joinTeam')->name('teams.join');
-    Route::get('view-join/{id}', 'TeamController@seeTeam')->name('teams.view');
+], function () {
 
-    Route::get('members/{id}', 'TeamMemberController@show')->name('teams.members.show');
-    Route::get('members/resend/{invite_id}', 'TeamMemberController@resendInvite')->name('teams.members.resend_invite');
-    Route::post('members/{id}', 'TeamMemberController@invite')->name('teams.members.invite');
-    Route::delete('members/{id}/{user_id}', 'TeamMemberController@destroy')->name('teams.members.destroy');
+    Route::get('/', 'TeamController@index')->name('index');
+    Route::get('create', 'TeamController@create')->name('create');
+    Route::post('teams', 'TeamController@store')->name('store');
+    Route::get('edit/{id}', 'TeamController@edit')->name('edit');
+    Route::put('edit/{id}', 'TeamController@update')->name('update');
+    Route::delete('destroy/{id}', 'TeamController@destroy')->name('destroy');
 
-    Route::delete('members/leave/{id}/{user_id}', 'TeamMemberController@leave')->name('teams.members.leave');
+    Route::get('switch/{id}', 'TeamController@switchTeam')->name('switch');
+    Route::post('join', 'TeamController@joinTeam')->name('join');
+    Route::get('view-join/{id}', 'TeamController@seeTeam')->name('view');
 
-    Route::get('accept/{token}', 'AuthController@acceptInvite')->name('teams.accept_invite');
-    Route::get('deny/{token}', 'AuthController@denyInvite')->name('teams.deny_invite');
+    Route::get('members/{id}', 'TeamMemberController@show')->name('members.show');
+    Route::get('members/resend/{invite_id}', 'TeamMemberController@resendInvite')->name('members.resend_invite');
+    Route::post('members/{id}', 'TeamMemberController@invite')->name('members.invite');
+    Route::delete('members/{id}/{user_id}', 'TeamMemberController@destroy')->name('members.destroy');
 
-    Route::get('create/event/{id}', 'TeamController@event')->name('teams.create.event');
+    Route::delete('members/leave/{id}/{user_id}', 'TeamMemberController@leave')->name('members.leave');
+
+    Route::get('accept/{token}', 'AuthController@acceptInvite')->name('accept_invite');
+    Route::get('deny/{token}', 'AuthController@denyInvite')->name('deny_invite');
+
+    Route::get('create/event/{id}', 'TeamController@event')->name('create.event');
+});
 //
 //->middleware('teamowner')

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,26 +36,6 @@ Route::group(['namespace' => 'Backend', 'prefix' => 'admin', 'as' => 'admin.', '
 
 });
 
-
-/**
- * Teamwork routes
- */
-Route::group(['prefix' => 'admin/teams', 'namespace' => 'Teamwork', 'middleware' => 'admin'], function()
-{
-     includeRouteFiles(__DIR__.'/Backend/Team/');
-});
-
-/**
-* Members route
-*/
-
-Route::group(['prefix' => 'admin/members', 'namespace' => 'Backend', 'as' => 'admin.', 'middleware' => 'admin'], function()
-{
-     includeRouteFiles(__DIR__.'/Backend/Members/');
-});
-
-
-
 /**
  * Messenger routes
  */


### PR DESCRIPTION
**What's this PR do?**

Closes https://github.com/kerongon/Collabo/issues/7

- Moves the team controllers into `Controllers\Backend\Teamwork`
- Deletes the route registration from the `web.php` route file
- Creates a teams group inside of the `team.php` route file
- Renames all occurences of `route('teams.*')` to `route('admin.teams.*')

**How should this be manually tested?**

Test all of the CRUD associated with teams, and check every page that uses an of the team controllers - i.e dashboard, teams etc.
